### PR TITLE
Ss fix select dba in clause

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,7 @@ releases
 /dist/
 /vthook/
 /bin/
-/vtdataroot/
+*vtdataroot/
 venv
 
 .scannerwork

--- a/go.sum
+++ b/go.sum
@@ -693,7 +693,6 @@ github.com/spyzhov/ajson v0.4.2 h1:JMByd/jZApPKDvNsmO90X2WWGbmT2ahDFp73QhZbg3s=
 github.com/spyzhov/ajson v0.4.2/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/go/test/endtoend/vtgate/system_schema_test.go
+++ b/go/test/endtoend/vtgate/system_schema_test.go
@@ -80,6 +80,11 @@ func TestInformationSchemaQuery(t *testing.T) {
 	assertResultIsEmpty(t, conn, "table_schema = 'performance_schema' and table_name = 'foo'")
 	assertSingleRowIsReturned(t, conn, "table_schema = 'vt_ks' and table_name = 't1'", "vt_ks")
 	assertSingleRowIsReturned(t, conn, "table_schema = 'ks' and table_name = 't1'", "vt_ks")
+	// run end to end test for in statement.
+	assertSingleRowIsReturned(t, conn, "table_schema IN ('ks')", "vt_ks")
+	assertSingleRowIsReturned(t, conn, "table_schema IN ('vt_ks')", "vt_ks")
+	assertSingleRowIsReturned(t, conn, "table_schema IN ('ks') and table_name = 't1'", "vt_ks")
+	assertSingleRowIsReturned(t, conn, "table_schema IN ('ks') and table_name IN ('t1')", "vt_ks")
 }
 
 func assertResultIsEmpty(t *testing.T, conn *mysql.Conn, pre string) {

--- a/go/vt/sqlparser/expression_converter.go
+++ b/go/vt/sqlparser/expression_converter.go
@@ -71,7 +71,6 @@ func Convert(e Expr) (evalengine.Expr, error) {
 			Left:  left,
 			Right: right,
 		}, nil
-
 	}
 	return nil, ErrExprNotSupported
 }

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -93,7 +93,7 @@ func TestBuilder(query string, vschema ContextVSchema) (*engine.Plan, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO(Scott): the actual execution path go through prepareAST first to normalize the variables. which is different than this one.
+	// TODO(Scott): the actual execution path go through prepareAST first to normalize the variables. which could be different than this one.
 	result, err := sqlparser.RewriteAST(stmt, "")
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -93,11 +93,11 @@ func TestBuilder(query string, vschema ContextVSchema) (*engine.Plan, error) {
 	if err != nil {
 		return nil, err
 	}
+	// TODO(Scott): the actual execution path go through prepareAST first to normalize the variables. which is different than this one.
 	result, err := sqlparser.RewriteAST(stmt, "")
 	if err != nil {
 		return nil, err
 	}
-
 	reservedVars := sqlparser.NewReservedVars("vtg", reserved)
 	return BuildFromStmt(query, result.AST, reservedVars, vschema, result.BindVarNeeds, true, true)
 }

--- a/go/vt/vtgate/planbuilder/fuzz.go
+++ b/go/vt/vtgate/planbuilder/fuzz.go
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-// +build gofuzz
 
 package planbuilder
 

--- a/go/vt/vtgate/planbuilder/system_tables.go
+++ b/go/vt/vtgate/planbuilder/system_tables.go
@@ -120,7 +120,7 @@ func extractInfoSchemaRoutingPredicate(in sqlparser.Expr) (bool, []evalengine.Ex
 			case sqlparser.ValTuple:
 				expressions = cmp.Right.(sqlparser.ValTuple)
 			case sqlparser.ListArg:
-				log.Errorf("Unsupport list args of in clause, need to be fixed %v", cmp.Right)
+				log.Infof("List Args of in clause is unsupport, please check if the statement is incorrectly normalized %v", cmp.Right.(sqlparser.ListArg))
 				return false, nil, nil
 			default:
 				return false, nil, nil

--- a/go/vt/vtgate/planbuilder/system_tables.go
+++ b/go/vt/vtgate/planbuilder/system_tables.go
@@ -18,26 +18,28 @@ package planbuilder
 
 import (
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/orchestrator/external/golib/log"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
 func (pb *primitiveBuilder) findSysInfoRoutingPredicates(expr sqlparser.Expr, rut *route) error {
-	isTableSchema, out, err := extractInfoSchemaRoutingPredicate(expr)
+	tableSchemas, tableNames, err := extractInfoSchemaRoutingPredicate(expr)
 	if err != nil {
 		return err
 	}
-	if len(out) == 0 {
+	if len(tableSchemas) == 0 && len(tableNames) == 0 {
 		// we didn't find a predicate to use for routing, so we just exit early
 		return nil
 	}
 
-	if isTableSchema {
-		rut.eroute.SysTableTableSchema = append(rut.eroute.SysTableTableSchema, out...)
-	} else {
-		rut.eroute.SysTableTableName = append(rut.eroute.SysTableTableName, out...)
+	if len(tableSchemas) > 0 {
+		rut.eroute.SysTableTableSchema = append(rut.eroute.SysTableTableSchema, tableSchemas...)
+	}
+
+	if len(tableNames) > 0 {
+		rut.eroute.SysTableTableName = append(rut.eroute.SysTableTableName, tableNames...)
 	}
 
 	return nil
@@ -74,7 +76,7 @@ func isTableNameCol(col *sqlparser.ColName) bool {
 	return col.Name.EqualString("table_name")
 }
 
-func extractInfoSchemaRoutingPredicate(in sqlparser.Expr) (bool, []evalengine.Expr, error) {
+func extractInfoSchemaRoutingPredicate(in sqlparser.Expr) ([]evalengine.Expr, []evalengine.Expr, error) {
 	switch cmp := in.(type) {
 	case *sqlparser.ComparisonExpr:
 		if cmp.Operator == sqlparser.EqualOp {
@@ -85,73 +87,146 @@ func extractInfoSchemaRoutingPredicate(in sqlparser.Expr) (bool, []evalengine.Ex
 					if err == sqlparser.ErrExprNotSupported {
 						// This just means we can't rewrite this particular expression,
 						// not that we have to exit altogether
-						return false, nil, nil
+						return nil, nil, nil
 					}
-					return false, nil, err
+					return nil, nil, err
 				}
-				var name string
+				exprs := []evalengine.Expr{evalExpr}
 				if isSchemaName {
-					name = sqltypes.BvSchemaName
-				} else {
-					name = engine.BvTableName
+					replaceOther(sqlparser.NewArgument(sqltypes.BvSchemaName))
+					return exprs, nil, nil
 				}
-				replaceOther(sqlparser.NewArgument(name))
-				return isSchemaName, []evalengine.Expr{evalExpr}, nil
+				replaceOther(sqlparser.NewArgument(engine.BvTableName))
+				return nil, exprs, nil
 			}
-		} else if cmp.Operator == sqlparser.InOp {
-			isSchema, isTable := isTableSchemaOrName(cmp.Left)
-			// should be either table schema or table name
-			if !isSchema && !isTable {
-				return false, nil, nil
+		} else if cmp.Operator == sqlparser.InOp || cmp.Operator == sqlparser.NotInOp {
+			// left side has to be the column, i.e (1, 2) IN column is not allowed.
+			// At least one column has to be DB name or table name.
+			colNames := checkAndSplitColumns(cmp.Left)
+			if colNames == nil {
+				return nil, nil, nil
 			}
-			// left side has to be the schema, i.e (1, 2) IN schema is not allowed.
-			if cmp.Left == nil {
-				return false, nil, nil
-			}
-			var name string
-			if isSchema {
-				name = sqltypes.BvSchemaName
-			} else {
-				name = engine.BvTableName
-			}
-			// TODO(Scott): other types like ColName is possible, need to be handled correctly later.
-			var expressions []sqlparser.Expr
-			switch cmp.Right.(type) {
-			case sqlparser.ValTuple:
-				expressions = cmp.Right.(sqlparser.ValTuple)
-			case sqlparser.ListArg:
-				log.Infof("List Args of in clause is unsupport, please check if the statement is incorrectly normalized %v", cmp.Right.(sqlparser.ListArg))
-				return false, nil, nil
-			default:
-				return false, nil, nil
+			valTuples := splitVals(cmp.Right, len(colNames))
+			// check if the val tuples format is correct.
+			if valTuples == nil {
+				return nil, nil, nil
 			}
 
-			// nameTuples are the tuples of __vtschemaname or database()
-			var nameTuples sqlparser.ValTuple
-			nameTuples = make([]sqlparser.Expr, 0, len(expressions))
-			valueTuples := make([]evalengine.Expr, 0, len(expressions))
-			for _, expr := range expressions {
-				if shouldRewrite(expr) {
-					nameTuples = append(nameTuples, sqlparser.Argument(name))
-					evalExpr, err := sqlparser.Convert(expr)
-					if err != nil {
-						if err == sqlparser.ErrExprNotSupported {
-							// This just means we can't rewrite this particular expression,
-							// not that we have to exit altogether
-							return false, nil, nil
-						}
-						return false, nil, err
-					}
-					valueTuples = append(valueTuples, evalExpr)
+			sysTableSchemas := make([]evalengine.Expr, 0, len(valTuples))
+			sysTableNames := make([]evalengine.Expr, 0, len(valTuples))
+			for index, col := range colNames {
+				isSchema, isTable := isTableSchemaOrName(col)
+				var name string
+				if isSchema {
+					name = sqltypes.BvSchemaName
+				} else if isTable {
+					name = engine.BvTableName
 				} else {
-					nameTuples = append(nameTuples, expr)
+					// only need to rewrite the SysTable and SysSchema
+					continue
+				}
+
+				for _, tuple := range valTuples {
+					expr := tuple[index]
+					if shouldRewrite(expr) {
+						tuple[index] = sqlparser.Argument(name)
+						evalExpr, err := sqlparser.Convert(expr)
+						if err != nil {
+							if err == sqlparser.ErrExprNotSupported {
+								// This just means we can't rewrite this particular expression,
+								// not that we have to exit altogether
+								return nil, nil, nil
+							}
+							return nil, nil, err
+						}
+						if isSchema {
+							sysTableSchemas = append(sysTableSchemas, evalExpr)
+						} else if isTable {
+							sysTableNames = append(sysTableNames, evalExpr)
+						}
+					}
 				}
 			}
-			cmp.Right = nameTuples
-			return isSchema, valueTuples, nil
+			// construct right side, rows of tuples of __vtschemaname or database()
+			cmp.Right = populateValTuple(valTuples, len(colNames))
+			return sysTableSchemas, sysTableNames, nil
 		}
 	}
-	return false, nil, nil
+	return nil, nil, nil
+}
+
+func populateValTuple(valTuples []sqlparser.ValTuple, numOfCol int) sqlparser.ValTuple {
+	var retValTuples sqlparser.ValTuple
+	retValTuples = make([]sqlparser.Expr, 0, len(valTuples))
+	for _, tuple := range valTuples {
+		if numOfCol == 1 {
+			// only one col per row, of colName type.
+			retValTuples = append(retValTuples, tuple[0])
+		} else {
+			retValTuples = append(retValTuples, tuple)
+		}
+	}
+	return retValTuples
+}
+
+// Convert the right side of In ops to a list of rows.
+func splitVals(e sqlparser.Expr, numOfCols int) []sqlparser.ValTuple {
+	// could either be (1, 2, 3) or ((1,2), (3,5))
+	expressions, ok := e.(sqlparser.ValTuple)
+	if !ok {
+		log.Errorf("Unsupported type, expecting val tuple %v", e)
+		return nil
+	}
+	valTuples := make([]sqlparser.ValTuple, 0, len(expressions))
+
+	for _, tuple := range expressions {
+		if numOfCols == 1 {
+			// values could be literal, float or other types.
+			valTuple := []sqlparser.Expr{tuple}
+			valTuples = append(valTuples, valTuple)
+		} else {
+			valTuple, ok := tuple.(sqlparser.ValTuple)
+			if !ok {
+				log.Errorf("Unsupported type, expecting a list of val tuple %v", tuple)
+				return nil
+			}
+			valTuples = append(valTuples, valTuple)
+		}
+
+	}
+	return valTuples
+}
+
+// Convert the left side of In ops to a list of columns.
+func checkAndSplitColumns(e sqlparser.Expr) []*sqlparser.ColName {
+	colNames := make([]*sqlparser.ColName, 0)
+	switch cols := e.(type) {
+	case sqlparser.ValTuple:
+		for _, col := range cols {
+			colName, ok := col.(*sqlparser.ColName)
+			if !ok {
+				log.Infof("left side of (not) in operator could not be converted to a list of col names. %v", col)
+				return nil
+			}
+			colNames = append(colNames, colName)
+		}
+	case *sqlparser.ColName:
+		colNames = append(colNames, cols)
+	default:
+		// unexpected left side of the in ops.
+		return nil
+	}
+	containDBName := false
+	containTableName := false
+	for _, col := range colNames {
+		containDBName = containDBName || isDbNameCol(col)
+		containTableName = containTableName || isTableNameCol(col)
+	}
+	if !containDBName && !containTableName {
+		log.Infof("left side of (not) in operator don't have a DB name or table name, don't need to rewrite. ")
+		return nil
+	}
+	return colNames
 }
 
 func shouldRewrite(e sqlparser.Expr) bool {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1932,6 +1932,25 @@ Gen4 plan same as above
   }
 }
 
+# schema name and table name of composite in clause.
+"SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE (TABLE_SCHEMA, TABLE_NAME, LOWER(COLUMN_NAME)) IN (('ks', 'route1', 'col'))"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE (TABLE_SCHEMA, TABLE_NAME, LOWER(COLUMN_NAME)) IN (('ks', 'route1', 'col'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select * from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
+    "Query": "select * from INFORMATION_SCHEMA.`TABLES` where (TABLE_SCHEMA, TABLE_NAME, LOWER(COLUMN_NAME)) in ((:__vtschemaname, :__vttablename, 'col'))",
+    "SysTableTableName": "[VARBINARY(\"route1\")]",
+    "SysTableTableSchema": "[VARBINARY(\"ks\")]"
+  }
+}
+
 # information_schema query using database() func
 "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = database()"
 {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1857,6 +1857,25 @@ Gen4 plan same as above
   }
 }
 
+# schema name and table name of in clause.
+"SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('ks') AND TABLE_NAME IN ('route1')"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('ks') AND TABLE_NAME IN ('route1')",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select * from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
+    "Query": "select * from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA in (:__vtschemaname) and TABLE_NAME in (:__vttablename)",
+    "SysTableTableName": "[VARBINARY(\"route1\")]",
+    "SysTableTableSchema": "[VARBINARY(\"ks\")]"
+  }
+}
+
 # information_schema query using database() func
 "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = database()"
 {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1821,6 +1821,42 @@ Gen4 plan same as above
   }
 }
 
+# query trying to query keyspace in clause with multiple values
+"SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('user','main')"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('user','main')",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select * from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
+    "Query": "select * from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA in (:__vtschemaname, :__vtschemaname)",
+    "SysTableTableSchema": "[VARBINARY(\"user\"), VARBINARY(\"main\")]"
+  }
+}
+
+# query trying to query keyspace in clause with multiple values
+"SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('user','main',database())"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('user','main',database())",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select * from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
+    "Query": "select * from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA in (:__vtschemaname, :__vtschemaname, database())",
+    "SysTableTableSchema": "[VARBINARY(\"user\"), VARBINARY(\"main\")]"
+  }
+}
+
 # information_schema query using database() func
 "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = database()"
 {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1839,6 +1839,24 @@ Gen4 plan same as above
   }
 }
 
+# query trying to query keyspace not in clause with multiple values
+"SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA NOT IN ('user','main')"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA NOT IN ('user','main')",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select * from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
+    "Query": "select * from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA not in (:__vtschemaname, :__vtschemaname)",
+    "SysTableTableSchema": "[VARBINARY(\"user\"), VARBINARY(\"main\")]"
+  }
+}
+
 # query trying to query keyspace in clause with multiple values
 "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('user','main',database())"
 {
@@ -1857,7 +1875,7 @@ Gen4 plan same as above
   }
 }
 
-# schema name and table name of in clause.
+# And two in-clause of sys table.
 "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('ks') AND TABLE_NAME IN ('route1')"
 {
   "QueryType": "SELECT",
@@ -1873,6 +1891,44 @@ Gen4 plan same as above
     "Query": "select * from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA in (:__vtschemaname) and TABLE_NAME in (:__vttablename)",
     "SysTableTableName": "[VARBINARY(\"route1\")]",
     "SysTableTableSchema": "[VARBINARY(\"ks\")]"
+  }
+}
+
+# schema name and table name of composite in clause.
+"SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE (TABLE_SCHEMA, TABLE_NAME) IN (('ks', 'route1'))"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE (TABLE_SCHEMA, TABLE_NAME) IN (('ks', 'route1'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select * from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
+    "Query": "select * from INFORMATION_SCHEMA.`TABLES` where (TABLE_SCHEMA, TABLE_NAME) in ((:__vtschemaname, :__vttablename))",
+    "SysTableTableName": "[VARBINARY(\"route1\")]",
+    "SysTableTableSchema": "[VARBINARY(\"ks\")]"
+  }
+}
+
+# schema name and table name of composite NOT in clause.
+"SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE (TABLE_SCHEMA, TABLE_NAME) NOT IN (('ks', 'route1'),('ks1','route2'))"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE (TABLE_SCHEMA, TABLE_NAME) NOT IN (('ks', 'route1'),('ks1','route2'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select * from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
+    "Query": "select * from INFORMATION_SCHEMA.`TABLES` where (TABLE_SCHEMA, TABLE_NAME) not in ((:__vtschemaname, :__vttablename), (:__vtschemaname, :__vttablename))",
+    "SysTableTableName": "[VARBINARY(\"route1\"), VARBINARY(\"route2\")]",
+    "SysTableTableSchema": "[VARBINARY(\"ks\"), VARBINARY(\"ks1\")]"
   }
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1803,6 +1803,24 @@ Gen4 plan same as above
   }
 }
 
+# query trying to query keyspace in clause
+"SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('user')"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('user')",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select * from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
+    "Query": "select * from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA in (:__vtschemaname)",
+    "SysTableTableSchema": "[VARBINARY(\"user\")]"
+  }
+}
+
 # information_schema query using database() func
 "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = database()"
 {


### PR DESCRIPTION
support correct parsing for the following scenarios for select DBA statement :
SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('commerce');

SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('commerce', 'product');

SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE (TABLE_SCHEMA,TABLE_NAME) IN (('commerce', 'product'));

select table_schema, table_name, column_name from information_schema.columns where (table_schema, table_name, lower(column_name)) in (('milkyway_production', 'user_uploaded_media', 'uuid'));

Noticed that due to the vttableschema and vttablename is still limited to 1, the actual query execution of above one may return less than what should be returned. The reason is vtgate using a map to track the overiden schema & table name, which could be only one. Further fix needed to make it work end to end.

Originally the code normalize the query
SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ('commerce', 'product');
to
SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN ::__vtg1;

this is undesired, because we need to rewrite the query to

"Query": "select * from INFORMATION_SCHEMA.TABLES where TABLE_SCHEMA in (:__vtschemaname, :__vtschemaname)",
"SysTableTableSchema": "[VARBINARY("commerce"), VARBINARY("product")]"

There are two ways to fix this:

rewrite the logic in normalize.go, make sure parse it like SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA IN (:__vtg1, :__vtg2);
add logic in normalize criteria and skip the normalization if it is a system table.
After implementing both, I found the 2 is less risky and has much less impact than 1.